### PR TITLE
Added support for ISO-8859-1 files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 anyhow = "1.0.86"
 clap = { version = "4.5.16", features = ["derive"] }
 piwis-val = { path = "crates/piwis-val" }
-quick-xml = { version = "0.36.1", features = ["serialize"] }
+quick-xml = { version = "0.36.1", features = ["serialize", "encoding"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_path_to_error = "0.1.16"
 serde-xml-rs = "0.6.0"

--- a/crates/piwis-val/Cargo.toml
+++ b/crates/piwis-val/Cargo.toml
@@ -10,6 +10,6 @@ serde = { version = "1.0.209", features = ["derive"] }
 serde_path_to_error = "0.1.16"
 serde-untagged = "0.1"
 serde-xml-rs = "0.6.0"
-quick-xml = { version = "0.36.1", features = ["serialize"] }
+quick-xml = { version = "0.36.1", features = ["serialize", "encoding"] }
 zip = "2.2.0"
 serde_json = "1.0.127"

--- a/crates/piwis-val/src/lib.rs
+++ b/crates/piwis-val/src/lib.rs
@@ -19,7 +19,7 @@ impl VehicleAnalysisLog {
         let mut archive = zip::ZipArchive::new(file)?;
         for i in 0..archive.len() {
             let file = archive.by_index(i)?;
-            if (file.name().starts_with("FAP_") || file.name().starts_with("OBD_")) && file.name().ends_with(".xml") {
+            if file.name().ends_with(".xml") {
                 let reader = BufReader::new(file);
                 let val = &mut quick_xml::de::Deserializer::from_reader(reader);
                 let deserialized: VehicleAnalysisLog = serde_path_to_error::deserialize(val).context("Failed deserializing")?;
@@ -81,7 +81,7 @@ pub struct VehicleIdentity {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
-#[serde(deny_unknown_fields, rename_all = "SCREAMING_SNAKE_CASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub struct VehicleData {
     pub odometer: UnitString,
     #[serde(rename = "OPERATINGTIME")]


### PR DESCRIPTION
I came across another type of Vehicle Analysis Log  file that can be supported. 
I think it’s generated when service VAL is created (at least on my car) but with some differences.

- The zip file starts with VIN instead of FAP_ or ODB_ prefix.
- XML file has MODEL subchild in Vehicle Data structure.
- For some reason the xml file is ISO-8859-1 encoded. 
